### PR TITLE
Add swift-argument-parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.swiftpm/xcode/xcshareddata/xcschemes/*.xcscheme

--- a/Package.resolved
+++ b/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
       "identity" : "xcconfig",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattmassicotte/XCConfig",

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,13 @@ let package = Package(
 	dependencies: [
 		.package(url: "https://github.com/tuist/XcodeProj", from: "8.15.0"),
 		.package(url: "https://github.com/mattmassicotte/XCConfig", branch: "main"),
+		.package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
 	],
 	targets: [
-		.executableTarget(name: "clitool", dependencies: ["XCLinting"]),
+		.executableTarget(name: "clitool", dependencies: [
+			"XCLinting",
+			.product(name: "ArgumentParser", package: "swift-argument-parser"),
+		]),
 		.target(name: "XCLinting", dependencies: ["XCConfig", "XcodeProj"]),
 		.testTarget(name: "XCLintTests", dependencies: ["XCLinting"]),
 

--- a/Sources/clitool/main.swift
+++ b/Sources/clitool/main.swift
@@ -1,4 +1,19 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
+import ArgumentParser
 
-print("Hello, world!")
+struct XCLintCommand: ParsableCommand {
+	static var configuration = CommandConfiguration(commandName: "xclint")
+
+	@Flag(
+		name: .shortAndLong,
+		help: "Print the version and exit."
+	)
+	var version: Bool = false
+	
+	func run() throws {
+		if version {
+			throw CleanExit.message("0.0.1")
+		}
+	}
+}
+
+XCLintCommand.main()


### PR DESCRIPTION
Initial step towards integrating [swift-argument-parser](https://github.com/apple/swift-argument-parser). The only thing it supports currently is printing the XCLint version, and the automatic help generated through `ParseableCommand`.

As this is my first PR to any of your repos, please feel free to correct my formatting or style! I was careful to maintain tab based indentation.