### PR TITLE
Add basic infrastructure for XCLinter

### DIFF
--- a/Sources/XCLinting/Configuration.swift
+++ b/Sources/XCLinting/Configuration.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XcodeProj
+import PathKit
+
+public final class Configuration {
+	public let project: XcodeProj
+	public let projectText: String
+	public let projectRoot: Path
+	
+	public init(project: XcodeProj, projectText: String, projectRoot: Path) {
+		self.project = project
+		self.projectText = projectText
+		self.projectRoot = projectRoot
+	}
+}

--- a/Sources/XCLinting/File.swift
+++ b/Sources/XCLinting/File.swift
@@ -1,2 +1,0 @@
-public struct XCLintThing {
-}

--- a/Sources/XCLinting/Rule.swift
+++ b/Sources/XCLinting/Rule.swift
@@ -1,0 +1,4 @@
+public protocol Rule {
+	init(configuration: Configuration)
+	func run() throws -> [Violation]
+}

--- a/Sources/XCLinting/Status.swift
+++ b/Sources/XCLinting/Status.swift
@@ -1,0 +1,5 @@
+public enum Status: Hashable {
+	case passed
+	case invalidInput
+	case failed
+}

--- a/Sources/XCLinting/Status.swift
+++ b/Sources/XCLinting/Status.swift
@@ -1,5 +1,0 @@
-public enum Status: Hashable {
-	case passed
-	case invalidInput
-	case failed
-}

--- a/Sources/XCLinting/Violation.swift
+++ b/Sources/XCLinting/Violation.swift
@@ -1,0 +1,11 @@
+import XcodeProj
+
+public struct Violation {
+	public var message: String
+	public var objects: [PBXObject]
+	
+	public init(_ message: String, objects: [PBXObject] = []) {
+		self.message = message
+		self.objects = objects
+	}
+}

--- a/Sources/XCLinting/XCLintError.swift
+++ b/Sources/XCLinting/XCLintError.swift
@@ -1,0 +1,16 @@
+public enum XCLintError: Error {
+	case noProjectFileSpecified
+	case projectFileNotFound(String)
+	case badProjectFile(Error)
+	
+	public var localizedDescription: String {
+		switch self {
+		case .noProjectFileSpecified:
+			return "Project file was not specified."
+		case let .projectFileNotFound(path):
+			return "Project file not found at '\(path)'."
+		case let .badProjectFile(error):
+			return "Bad project file: \(error.localizedDescription)."
+		}
+	}
+}

--- a/Sources/XCLinting/XCLinter.swift
+++ b/Sources/XCLinting/XCLinter.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XcodeProj
+import PathKit
+
+public struct XCLinter {
+	public var configuration: Configuration
+	public var rules: [Rule.Type]
+	
+	public init(projectPath: String) throws {
+		guard !projectPath.isEmpty else {
+			throw XCLintError.noProjectFileSpecified
+		}
+
+		let path = Path(projectPath)
+		guard path.isDirectory else {
+			throw XCLintError.projectFileNotFound(projectPath)
+		}
+
+		let xcodeproj: XcodeProj
+		let projectText: String
+		do {
+			xcodeproj = try XcodeProj(path: path)
+			projectText = try String(contentsOf: URL(fileURLWithPath: projectPath).appendingPathComponent("project.pbxproj"))
+		} catch {
+			throw XCLintError.badProjectFile(error)
+		}
+		
+		self.init(configuration: Configuration(project: xcodeproj, projectText: projectText, projectRoot: path), rules: [])
+	}
+	
+	public init(configuration: Configuration, rules: [Rule.Type]) {
+		self.configuration = configuration
+		self.rules = rules
+	}
+	
+	public func run() throws -> [Violation] {
+		var violations = [Violation]()
+		for ruleType in rules {
+			let rule = ruleType.init(configuration: configuration)
+			violations.append(contentsOf: try rule.run())
+		}
+		return violations
+	}
+}

--- a/Sources/clitool/main.swift
+++ b/Sources/clitool/main.swift
@@ -1,4 +1,8 @@
+import Foundation
 import ArgumentParser
+import XcodeProj
+import PathKit
+import XCLinting
 
 struct XCLintCommand: ParsableCommand {
 	static var configuration = CommandConfiguration(commandName: "xclint")
@@ -9,9 +13,34 @@ struct XCLintCommand: ParsableCommand {
 	)
 	var version: Bool = false
 	
+	@Argument(help: "The path to the .xcodeproj bundle to lint.")
+	var projectFile: String = ""
+
 	func run() throws {
 		if version {
 			throw CleanExit.message("0.0.1")
+		}
+		
+		let linter: XCLinter
+		do {
+			linter = try XCLinter(projectPath: projectFile)
+		} catch {
+			throw ValidationError(error.localizedDescription)
+		}
+
+		let violations: [Violation]
+		do {
+			violations = try linter.run()
+		} catch {
+			throw ValidationError(error.localizedDescription)
+		}
+		
+		for violation in violations {
+			print(violation.message)
+		}
+		
+		if !violations.isEmpty {
+			throw ExitCode.failure
 		}
 	}
 }

--- a/Tests/XCLintTests/XCLintTests.swift
+++ b/Tests/XCLintTests/XCLintTests.swift
@@ -1,7 +1,0 @@
-import XCTest
-import XCLinting
-
-final class XCLintTests: XCTestCase {
-	func testExample() throws {
-	}
-}

--- a/Tests/XCLintTests/XCLinterTests.swift
+++ b/Tests/XCLintTests/XCLinterTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import XCLinting
+
+final class XCLinterTests: XCTestCase {
+	
+	func testEmptyProjectPathThrowsError() throws {
+		do {
+			_ = try XCLinter(projectPath: "")
+			XCTFail()
+		} catch XCLintError.noProjectFileSpecified {
+		} catch {
+			XCTFail("wrong error: \(error)")
+		}
+	}
+	
+	
+	func testMissingProjectFileThrowsError() throws {
+		do {
+			_ = try XCLinter(projectPath: "/dev/null")
+			XCTFail()
+		} catch XCLintError.projectFileNotFound {
+		} catch {
+			XCTFail("wrong error: \(error)")
+		}
+	}
+}


### PR DESCRIPTION
This adds some basic infrastructure for the linter:

- `XCLinter` is a new primary type within the XCLinting module. It is used to run a linting operation.
- `Configuration` contains basic information for use within `XCLinter`: the parsed project file, the string contents of the project file, and the location of the project file on disk. Since this type will be passed around frequently, I made it an immutable class, to avoid any expensive copies. I expect this type to grow over time to include things like folder/groups to skip and any other options.
- `Rule` is a protocol that establishes the interface for each lint rule that might be defined. Pretty simple for now, just an `init` that accepts the `Configuration` and a single `run()` method.
- `Violation`s are returned by a `Rule` representing any rule violations that occur. I'm not sure what exactly will be needed by this type, but for now it just has a `message` and optionally an array of `PBXObject`s.
- Finally there's `XCLintError`, a simple Error type thrown when setting up `XCLinter`. Again, not quite sure what else will be needed in here, but for it contains a few simple file errors when reading in the project file.

`XCLinter` can be initialized with a path to the project file or with a fleshed out `Configuration`. When supplied with a path, it will attempt to read in and parse the project file, throwing errors if anything fails. I added a couple simple tests around these errors, just to get the ball rolling on tests.

Once setup, `XCLinter` has its `run()` method which will iteratively initialize and run each rule, collecting any `Violation`s. If any violations are found, the command line exits with code 1, printing the messages from the violations. Otherwise exit with code 0.

I realize this is a ton of code to add to your project. Feel free to comment or edit any of it. I'm very interested in this topic and would love to see this project succeed. Thank you!