### PR TITLE
[Draft] Add buildFilesAreOrderedRule

### DIFF
--- a/Sources/XCLinting/Rules/BuildFilesAreOrderedRule.swift
+++ b/Sources/XCLinting/Rules/BuildFilesAreOrderedRule.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+func buildFilesAreOrderedRule(_ environment: XCLinter.Environment) throws -> [Violation] {
+	let projectText = try String(contentsOf: environment.projectRootURL.appendingPathComponent("project.pbxproj"))
+	var violations = [Violation]()
+	violations.append(contentsOf: try validateSection(forType: "PBXBuildFile", projectText: projectText))
+	violations.append(contentsOf: try validateSection(forType: "PBXFileReference", projectText: projectText))
+	return violations
+}
+
+private func validateSection(forType sectionType: String, projectText: String) throws -> [Violation] {
+	// Find the range in projectText for the sectionType
+	guard let range = getSectionRange(forType: sectionType, projectText: projectText) else {
+		throw XCLintError.badProjectFile("Missing \(sectionType) section")
+	}
+	
+	// split this range of projectText into lines. convert to String now to
+	// avoid repeated conversions when applying the regex
+	let lines = projectText[range].split(separator: "\n").map(String.init)
+	
+	// verify that there is more than one item in this section, otherwise no violations
+	guard var previousLine = lines.first, lines.count > 1 else { return [] }
+	var previousId = getId(from: previousLine)
+	
+	var violations = [Violation]()
+	
+	for line in lines.dropFirst() {
+		let id = getId(from: line)
+		
+		// compare the identifiers of this line with the previous line
+		if verify(previousId, isLessThan: id) == false {
+			violations.append(.init("\(sectionType) \(violationNote(from: line)) is out of order with \(violationNote(from: previousLine))."))
+		}
+		previousId = id
+		previousLine = line
+	}
+	
+	return violations
+}
+
+private func getSectionRange(forType sectionType: String, projectText: String) -> Range<String.Index>? {
+	guard let start = projectText.range(of: "/* Begin \(sectionType) section */\n"),
+		  let end = projectText.range(of: "/* End \(sectionType) section */"),
+		  start.upperBound < end.lowerBound
+	else { return nil }
+	return start.upperBound..<end.lowerBound
+}
+
+private let lineRegex = try! NSRegularExpression(pattern: #"^\s*([A-Z0-9]{24})\s+\/\*\s([^\*]*)\s\*\/"#, options: [])
+
+/// This function will find the `Substring` for the id of the PBXBuildFile or PBXFileReference
+private func getId(from line: String) -> Substring {
+	guard let match = lineRegex.firstMatch(in: line, options: [], range: line.nsrange),
+		  let idRange = Range(match.range(at: 1), in: line)
+	else { fatalError() }
+	return line[idRange]
+}
+
+private func getFileInfo(from line: String) -> Substring {
+	guard let match = lineRegex.firstMatch(in: line, options: [], range: line.nsrange),
+		  let infoRange = Range(match.range(at: 2), in: line)
+	else { fatalError() }
+	return line[infoRange]
+}
+
+private func violationNote(from line: String) -> String {
+	let id = getId(from: line)
+	let info = getFileInfo(from: line)
+	return "'(\(id)) \(info)'"
+}
+
+/// This function will compare two ids, passed in as Substrings, which should be the same length.
+/// Starting from the beginning of each substring, the first UTF8 character that is not exactly
+/// the same between the two ids is compared.
+private func verify(_ id1: Substring, isLessThan id2: Substring) -> Bool {
+	guard let firstDifferingElement = zip(id1.utf8, id2.utf8).lazy.first(where: { $0.1 != $0.0 }) else { return false }
+	return firstDifferingElement.0 < firstDifferingElement.1
+}
+
+private extension String {
+	var nsrange: NSRange { NSRange(startIndex..<endIndex, in: self) }
+}

--- a/Sources/XCLinting/XCLintError.swift
+++ b/Sources/XCLinting/XCLintError.swift
@@ -1,7 +1,7 @@
 public enum XCLintError: Error {
 	case noProjectFileSpecified
 	case projectFileNotFound(String)
-	case badProjectFile(Error)
+	case badProjectFile(String)
 	
 	public var localizedDescription: String {
 		switch self {
@@ -9,8 +9,8 @@ public enum XCLintError: Error {
 			return "Project file was not specified."
 		case let .projectFileNotFound(path):
 			return "Project file not found at '\(path)'."
-		case let .badProjectFile(error):
-			return "Bad project file: \(error.localizedDescription)."
+		case let .badProjectFile(message):
+			return "Bad project file: \(message)."
 		}
 	}
 }

--- a/Sources/XCLinting/XCLinter.swift
+++ b/Sources/XCLinting/XCLinter.swift
@@ -58,6 +58,6 @@ extension XCLinter.Environment {
 extension XCLinter {
 	public static let defaultRules: [Rule] = [
 		embeddedBuildSettingsRule,
-		buildFilesAreOrderedRule
+		{ try BuildFilesAreOrderedRule().run($0) }
 	]
 }

--- a/Sources/XCLinting/XCLinter.swift
+++ b/Sources/XCLinting/XCLinter.swift
@@ -57,6 +57,7 @@ extension XCLinter.Environment {
 
 extension XCLinter {
 	public static let defaultRules: [Rule] = [
-		embeddedBuildSettingsRule
+		embeddedBuildSettingsRule,
+		buildFilesAreOrderedRule
 	]
 }

--- a/Tests/XCLintTests/BuildFilesAreOrderedTests.swift
+++ b/Tests/XCLintTests/BuildFilesAreOrderedTests.swift
@@ -9,7 +9,7 @@ final class BuildFilesAreOrderedTests: XCTestCase {
 		
 		let project = try XcodeProj(pathString: url.path)
 		
-		let rules: [XCLinter.Rule] = [buildFilesAreOrderedRule]
+		let rules: [XCLinter.Rule] = [{ try BuildFilesAreOrderedRule().run($0) }]
 		
 		let env = XCLinter.Environment(
 			project: project,
@@ -27,7 +27,7 @@ final class BuildFilesAreOrderedTests: XCTestCase {
 		
 		let project = try XcodeProj(pathString: url.path)
 		
-		let rules: [XCLinter.Rule] = [buildFilesAreOrderedRule]
+		let rules: [XCLinter.Rule] = [{ try BuildFilesAreOrderedRule().run($0) }]
 		
 		let env = XCLinter.Environment(
 			project: project,

--- a/Tests/XCLintTests/BuildFilesAreOrderedTests.swift
+++ b/Tests/XCLintTests/BuildFilesAreOrderedTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import XCLinting
+import XcodeProj
+
+final class BuildFilesAreOrderedTests: XCTestCase {
+	func testProjectWithOrderedFiles() throws {
+		let url = try Bundle.module.testDataURL(named: "StockMacOSApp.xcodeproj")
+		
+		let project = try XcodeProj(pathString: url.path)
+		
+		let rules: [XCLinter.Rule] = [buildFilesAreOrderedRule]
+		
+		let env = XCLinter.Environment(
+			project: project,
+			projectRootURL: url,
+			configuration: Configuration()
+		)
+		
+		let violations = try rules.flatMap { try $0(env) }
+		
+		XCTAssertTrue(violations.isEmpty)
+	}
+	
+	func testProjectWithOutOfOrderFiles() throws {
+		let url = try Bundle.module.testDataURL(named: "BuildFilesOutOfOrder.xcodeproj")
+		
+		let project = try XcodeProj(pathString: url.path)
+		
+		let rules: [XCLinter.Rule] = [buildFilesAreOrderedRule]
+		
+		let env = XCLinter.Environment(
+			project: project,
+			projectRootURL: url,
+			configuration: Configuration()
+		)
+		
+		let violations = try rules.flatMap { try $0(env) }
+		
+		XCTAssertFalse(violations.isEmpty)
+	}
+}
+

--- a/Tests/XCLintTests/EmbeddedBuildSettingsRuleTests.swift
+++ b/Tests/XCLintTests/EmbeddedBuildSettingsRuleTests.swift
@@ -26,7 +26,7 @@ final class EmbeddedBuildSettingsRuleTests: XCTestCase {
 
 		let env = XCLinter.Environment(
 			project: project,
-			projectRootURL: URL(fileURLWithPath: "/dev/null"),
+			projectRootURL: url,
 			configuration: Configuration()
 		)
 
@@ -44,7 +44,7 @@ final class EmbeddedBuildSettingsRuleTests: XCTestCase {
 
 		let env = XCLinter.Environment(
 			project: project,
-			projectRootURL: URL(fileURLWithPath: "/dev/null"),
+			projectRootURL: url,
 			configuration: Configuration()
 		)
 

--- a/Tests/XCLintTests/TestData/BuildFilesOutOfOrder.xcodeproj/project.pbxproj
+++ b/Tests/XCLintTests/TestData/BuildFilesOutOfOrder.xcodeproj/project.pbxproj
@@ -1,0 +1,346 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		C965BD2C2AE6E5D700E5836A /* StockMacOSAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C965BD2B2AE6E5D700E5836A /* StockMacOSAppApp.swift */; };
+		C965BD2E2AE6E5D700E5836A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C965BD2D2AE6E5D700E5836A /* ContentView.swift */; };
+		C965BD332AE6E5D800E5836A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C965BD322AE6E5D800E5836A /* Preview Assets.xcassets */; };
+		C965BD302AE6E5D800E5836A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C965BD2F2AE6E5D800E5836A /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		C965BD282AE6E5D700E5836A /* StockMacOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StockMacOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C965BD2B2AE6E5D700E5836A /* StockMacOSAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockMacOSAppApp.swift; sourceTree = "<group>"; };
+		C965BD2D2AE6E5D700E5836A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		C965BD322AE6E5D800E5836A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		C965BD2F2AE6E5D800E5836A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C965BD342AE6E5D800E5836A /* StockMacOSApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StockMacOSApp.entitlements; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C965BD252AE6E5D700E5836A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C965BD1F2AE6E5D700E5836A = {
+			isa = PBXGroup;
+			children = (
+				C965BD2A2AE6E5D700E5836A /* StockMacOSApp */,
+				C965BD292AE6E5D700E5836A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C965BD292AE6E5D700E5836A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C965BD282AE6E5D700E5836A /* StockMacOSApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C965BD2A2AE6E5D700E5836A /* StockMacOSApp */ = {
+			isa = PBXGroup;
+			children = (
+				C965BD2B2AE6E5D700E5836A /* StockMacOSAppApp.swift */,
+				C965BD2D2AE6E5D700E5836A /* ContentView.swift */,
+				C965BD2F2AE6E5D800E5836A /* Assets.xcassets */,
+				C965BD342AE6E5D800E5836A /* StockMacOSApp.entitlements */,
+				C965BD312AE6E5D800E5836A /* Preview Content */,
+			);
+			path = StockMacOSApp;
+			sourceTree = "<group>";
+		};
+		C965BD312AE6E5D800E5836A /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				C965BD322AE6E5D800E5836A /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C965BD272AE6E5D700E5836A /* StockMacOSApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C965BD372AE6E5D800E5836A /* Build configuration list for PBXNativeTarget "StockMacOSApp" */;
+			buildPhases = (
+				C965BD242AE6E5D700E5836A /* Sources */,
+				C965BD252AE6E5D700E5836A /* Frameworks */,
+				C965BD262AE6E5D700E5836A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StockMacOSApp;
+			productName = StockMacOSApp;
+			productReference = C965BD282AE6E5D700E5836A /* StockMacOSApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C965BD202AE6E5D700E5836A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1510;
+				LastUpgradeCheck = 1510;
+				TargetAttributes = {
+					C965BD272AE6E5D700E5836A = {
+						CreatedOnToolsVersion = 15.1;
+					};
+				};
+			};
+			buildConfigurationList = C965BD232AE6E5D700E5836A /* Build configuration list for PBXProject "StockMacOSApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C965BD1F2AE6E5D700E5836A;
+			productRefGroup = C965BD292AE6E5D700E5836A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C965BD272AE6E5D700E5836A /* StockMacOSApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C965BD262AE6E5D700E5836A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C965BD332AE6E5D800E5836A /* Preview Assets.xcassets in Resources */,
+				C965BD302AE6E5D800E5836A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C965BD242AE6E5D700E5836A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C965BD2E2AE6E5D700E5836A /* ContentView.swift in Sources */,
+				C965BD2C2AE6E5D700E5836A /* StockMacOSAppApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C965BD352AE6E5D800E5836A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C965BD362AE6E5D800E5836A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		C965BD382AE6E5D800E5836A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = StockMacOSApp/StockMacOSApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"StockMacOSApp/Preview Content\"";
+				DEVELOPMENT_TEAM = 77X93NZ3G2;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.massicotte.StockMacOSApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		C965BD392AE6E5D800E5836A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = StockMacOSApp/StockMacOSApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"StockMacOSApp/Preview Content\"";
+				DEVELOPMENT_TEAM = 77X93NZ3G2;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.massicotte.StockMacOSApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C965BD232AE6E5D700E5836A /* Build configuration list for PBXProject "StockMacOSApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C965BD352AE6E5D800E5836A /* Debug */,
+				C965BD362AE6E5D800E5836A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C965BD372AE6E5D800E5836A /* Build configuration list for PBXNativeTarget "StockMacOSApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C965BD382AE6E5D800E5836A /* Debug */,
+				C965BD392AE6E5D800E5836A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C965BD202AE6E5D700E5836A /* Project object */;
+}

--- a/Tests/XCLintTests/TestData/BuildFilesOutOfOrder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/XCLintTests/TestData/BuildFilesOutOfOrder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tests/XCLintTests/TestData/BuildFilesOutOfOrder.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Tests/XCLintTests/TestData/BuildFilesOutOfOrder.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This adds the `buildFilesAreOrderedRule` and some simple tests to validate it.

The `buildFilesAreOrderedRule` verifies that the items in the PBXBuildFile and PBXFileReference sections of the project file are ordered by their identifiers. In normal use, Xcode tolerates items that are out of order, but writes them out in order. This can create churn on a large project files with several contributors. And this frequently occurs on bad merges or rebases, where the author is not careful to maintain the order when resolving conflicts.

`buildFilesAreOrderedRule` follows the existing pattern of being a pure function, but this ends up being a bit cumbersome. I added several utility functions to make this code easier to understand. And while these _are_ private, it feels odd having them at the global level. I tried making them nested functions of `buildFilesAreOrderedRule()`, but that was even harder to read. If these methods were members of specific type, then there would be no risk of collisions with other functions elsewhere in the library. This rule also uses an `NSRegularExpression` to parse lines in the project file, and this also has to be a global value.

This rule does not operate on the parsed `XcodeProj` model, instead it operates on the raw text of the project file. Luckily, `Environment` maintains the URL of the xcodeproj bundle on disk, so it's easy to read this data in. But if there are other rules in the future that also need to operate on the text, then it may be wasteful to read it in multiple times.

I copied the tests in `EmbeddedBuildSettingsRuleTests` and updated them for this new rule, using a test project file I added. This project includes out of order entries in both the PBXBuildFile and PBXFileReference sections.

You should feel empowered to make any and all edits you deem appropriate, or even reject this PR outright. I'm excited to contribute to this project, but I acknowledge not much is setup yet and you may have a vision for where you want it to go. Thank you!